### PR TITLE
Fix InvalidStateError when switching audio tracks

### DIFF
--- a/src/boom.ts
+++ b/src/boom.ts
@@ -19,6 +19,7 @@ const barSpacingPercent = 100 / analyser.frequencyBinCount;
 const currentAudio = undefined;
 const frequencyData = new Uint8Array(analyser.frequencyBinCount);
 let sourceNode: MediaElementAudioSourceNode | undefined = undefined;
+let connectedAudio: HTMLAudioElement | undefined = undefined;
 const visualisation = document.getElementById("viz");
 
 class Boomer {
@@ -391,7 +392,11 @@ const Synth = {
     if (sourceNode) {
       sourceNode.disconnect();
     }
-    sourceNode = context.createMediaElementSource(currentAudio);
+    // Only create a new MediaElementAudioSourceNode if this is a different audio element
+    if (connectedAudio !== currentAudio) {
+      sourceNode = context.createMediaElementSource(currentAudio);
+      connectedAudio = currentAudio;
+    }
     // @ts-ignore
     sourceNode.connect(analyser);
     analyser.connect(context.destination);


### PR DESCRIPTION
Prevent InvalidStateError by tracking the connected audio element, ensuring that a new MediaElementAudioSourceNode is only created for a different audio element. This change allows for seamless playback of different tracks without encountering connection errors.